### PR TITLE
Add support for other boot1 versions

### DIFF
--- a/firmware/programs/hexcore/source/imports.c
+++ b/firmware/programs/hexcore/source/imports.c
@@ -40,6 +40,11 @@ int enc_prsh(u32 addr, u32 size, void* iv_buf, u32 iv_size)
 	return ((int (*const)(u32, u32, void*, u32))MCP_ENC_PRSH)(addr, size, iv_buf, iv_size);
 }
 
+void load_boot1_params()
+{
+	((void (*const)(void))MCP_LOAD_BOOT1_PARAMS)();
+}
+
 void* memset(void* dst, int val, size_t size)
 {
 	char* _dst = dst;

--- a/firmware/programs/hexcore/source/imports.h
+++ b/firmware/programs/hexcore/source/imports.h
@@ -16,6 +16,7 @@
 #define MCP_BSP_WRITE ((void*)0x05059570)
 #define MCP_FLUSH_DCACHE ((void*)0x05059178)
 #define MCP_ENC_PRSH ((void*)0x0500A611)
+#define MCP_LOAD_BOOT1_PARAMS ((void*)0x05006A29)
 
 void usleep(u32 time);
 void seeprom_read(u32 offset, u32 size, void* out_buf);
@@ -25,5 +26,6 @@ int bsp_read(char *entity, u32 offset, char* param, u32 out_size, void* out_buf)
 int bsp_write(char *entity, u32 offset, char* param, u32 in_size, void* in_buf);
 void flush_dcache(u32 addr, u32 size);
 int enc_prsh(u32 addr, u32 size, void* iv_buf, u32 iv_size);
+void load_boot1_params();
 
 #endif


### PR DESCRIPTION
Adds support for dumping other boot1 versions with boot1hax.

I've tested the changes with all the added versions, however I wasn't able to verify if there happen to be additional leftover runtime informations in older version dumps, as I used only one console for testing.

(the older versions were initially obtained by bruteforcing boot_info addresses to corrupt until the execution fell to NULL, reported here: https://gist.github.com/rw-r-r-0644/19f661bb0166072b7dc6e26ca0b5a6d2 ...this also ended up accidentally finding some different corruption targets haha)